### PR TITLE
Updated module names in sphinx rst file

### DIFF
--- a/docs_sphinx/SciServer.rst
+++ b/docs_sphinx/SciServer.rst
@@ -12,26 +12,26 @@ SciServer.CasJobs module
     :undoc-members:
     :show-inheritance:
 
-SciServer.Files module
-----------------------
-
-.. automodule:: SciServer.Files
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-SciServer.Keystone module
+SciServer.SciDrive module
 -------------------------
 
-.. automodule:: SciServer.Keystone
+.. automodule:: SciServer.SciDrive
     :members:
     :undoc-members:
     :show-inheritance:
 
-SciServer.Session module
-------------------------
+SciServer.LoginPortal module
+----------------------------
 
-.. automodule:: SciServer.Session
+.. automodule:: SciServer.LoginPortal
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+SciServer.SkyServer module
+--------------------------
+
+.. automodule:: SciServer.SkyServer
     :members:
     :undoc-members:
     :show-inheritance:


### PR DESCRIPTION
The documentation wasn't building, because the module names were wrong. This is just a simple update to fix that.
